### PR TITLE
Add .gitignore to exclude build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Build artifacts
+awsid_darwin_amd64
+awsid_darwin_arm64
+awsid_linux_amd64
+
+# Distribution files
+dist/
+
+# Go build cache
+.cache/
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- Add comprehensive .gitignore file to exclude build artifacts and development files
- Prevent platform-specific binaries from being tracked in git
- Exclude dist/ directory and common IDE/OS files

## Test plan
- [x] Verify .gitignore excludes build files correctly
- [x] Confirm no unwanted files are tracked
- [x] Test build process still works normally

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a `.gitignore` file to prevent build artifacts, IDE settings, temporary files, and OS-specific files from being tracked by version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->