### PR TITLE
[update] バージョンを 0.2.1 に更新

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ type AccountInfoList struct {
 	Accounts []AccountInfo `json:"account_info"`
 }
 
-const Version = "0.2.0"
+const Version = "0.2.1"
 
 func main() {
 	var jsonOutput bool


### PR DESCRIPTION
## 概要

アプリケーション内のバージョン定数を0.2.1に更新しました。

## 背景

バージョンコマンド機能が追加されたため、パッチバージョンアップを行い、リリース準備のためにバージョン定数を更新する必要があるため。

## 内容詳細

- main.goのVersion定数を\0.2.0\から\0.2.1\に更新
- --versionコマンドで正しいバージョンが表示されるようになる

## レビューポイント

- バージョン定数が適切に更新されているか
- セマンティックバージョニングが適切に適用されているか

🤖 Generated with [Claude Code](https://claude.ai/code)