### PR TITLE
AWS Organizations API 呼び出し時のリージョン自動設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,15 @@ brew install awsid
 
 ### 設定
 
-`~/.aws/account_info` ファイルにCSV形式でアカウント情報を記載します：
+#### アカウント情報の自動取得
+
+このツールは AWS Organizations API を使用してアカウント情報を自動的に取得し、`~/.aws/account_info` ファイルにCSV形式で保存します。
+
+**重要**: AWS Organizations API の呼び出しには us-east-1 リージョンが使用されます。これは AWS Organizations がグローバルサービスであり、標準的なリージョンとして us-east-1 が推奨されているためです。
+
+#### 手動設定（オプション）
+
+必要に応じて、`~/.aws/account_info` ファイルを手動で編集することも可能です：
 
 ```csv
 alias_name,account_id

--- a/main.go
+++ b/main.go
@@ -232,8 +232,8 @@ func updateAccountInfoFromAWS(filePath string) error {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
 
-	// Load AWS configuration
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+	// Load AWS configuration with us-east-1 region (Organizations is global but requires a region)
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-east-1"))
 	if err != nil {
 		return fmt.Errorf("failed to load AWS config: %w", err)
 	}


### PR DESCRIPTION
## 概要

Issue #10 に対応し、AWS Organizations API を呼び出す際にリージョンを us-east-1 に自動設定するよう修正しました。

## 背景

AWS Organizations はグローバルサービスですが、API 呼び出し時にはリージョンの指定が必要です。現在の実装では、ユーザーの AWS 設定でリージョンが未指定の場合にエラーが発生する可能性がありました。

## 内容詳細

- AWS SDK の `config.LoadDefaultConfig` に `config.WithRegion("us-east-1")` を追加
- AWS Organizations API の標準的なリージョンである us-east-1 を自動設定
- ユーザーがリージョンを設定していない場合でも確実に動作するよう改善

## レビューポイント

- リージョン設定が適切に追加されているか
- 既存の機能に影響がないか
- AWS Organizations の標準的なリージョン指定が正しいか

Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AWS integration reliability by ensuring the correct region is set for AWS Organizations operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->