### PR TITLE
alias_name の検索を前方一致から部分一致に変更

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 			matchingAccounts := []AccountInfo{}
 
 			for _, account := range accounts {
-				if strings.HasPrefix(account.AliasName, searchTerm) {
+				if strings.Contains(account.AliasName, searchTerm) {
 					matchingAccounts = append(matchingAccounts, account)
 				}
 			}


### PR DESCRIPTION
## 概要

Issue #13 に対応し、alias_name の検索を前方一致（prefix match）から部分一致（partial match）に変更しました。

## 背景

現在の実装では `strings.HasPrefix()` を使用しており、指定した文字列で始まるエイリアス名のみが検索対象となっていました。しかし、実際の運用では以下のようなケースで不便でした：

- `test-prod` というアカウントを `prod` で検索したい場合
- `my-dev-account` というアカウントを `dev` で検索したい場合

## 内容詳細

- `strings.HasPrefix()` から `strings.Contains()` への変更
- より直感的で柔軟な検索機能を提供
- 既存の完全一致優先の動作は維持

## 変更内容

```go
// 変更前（前方一致）
if strings.HasPrefix(account.AliasName, searchTerm) {

// 変更後（部分一致）
if strings.Contains(account.AliasName, searchTerm) {
```

## レビューポイント

- 部分一致検索が正しく動作するか
- 完全一致優先の動作が維持されているか
- 既存の機能に影響がないか

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AWS account search to match aliases containing the search term, not just those starting with it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->