### PR TITLE
AWS Organizationsの全情報をCSVに保存

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+AWSID is a Go CLI tool that retrieves AWS account IDs from alias names using AWS Organizations API. It's a single-file Go application (`main.go`) that automatically fetches account information and provides multiple output formats (standard, JSON, table, CSV).
+
+## Architecture
+
+- **Single binary**: All functionality is contained in `main.go`
+- **Data storage**: Account information is cached in `~/.aws/account_info` as CSV
+- **AWS Integration**: Uses AWS SDK v2 with Organizations service (requires us-east-1 region)
+- **CLI Framework**: Built with Cobra for command-line interface
+- **Search Logic**: Supports both exact and partial matching with different output behaviors
+
+## Key Components
+
+- `AccountInfo` struct: Core data model for alias name and account ID pairs
+- `readAccountInfo()`: CSV file parser with header detection
+- `updateAccountInfoFromAWS()`: AWS Organizations API integration
+- Output formatters: `outputJSON()`, `outputTable()`, `outputCSV()`
+- Search logic: Exact match returns account ID only, partial matches show "alias: id" format
+
+## Build and Development Commands
+
+```bash
+# Build for current platform
+go build -o awsid
+
+# Run without building
+go run main.go [args]
+
+# Test (no test files currently exist)
+go test
+
+# Format code
+go fmt
+
+# Vet code for issues
+go vet
+
+# Get dependencies
+go mod tidy
+
+# Cross-compile for multiple platforms (like existing dist/ binaries)
+GOOS=darwin GOARCH=amd64 go build -o awsid_darwin_amd64
+GOOS=darwin GOARCH=arm64 go build -o awsid_darwin_arm64
+GOOS=linux GOARCH=amd64 go build -o awsid_linux_amd64
+GOOS=windows GOARCH=amd64 go build -o awsid_windows_amd64.exe
+```
+
+## Dependencies
+
+- `github.com/spf13/cobra`: CLI framework
+- `github.com/olekukonko/tablewriter`: Table output formatting
+- `github.com/aws/aws-sdk-go-v2/*`: AWS SDK for Organizations API
+
+## Important Notes
+
+- AWS Organizations API calls are hardcoded to use us-east-1 region
+- Account info file location is fixed at `~/.aws/account_info`
+- No test files exist currently - consider adding when implementing new features
+- Version is hardcoded in main.go as a const (currently "0.4.0")
+
+## AWS Organizations Access
+
+**IMPORTANT**: When accessing AWS Organizations API, always switch to the org profile first:
+
+```bash
+# Switch to Organizations profile and run awsid
+chprof org && ./awsid
+
+# Test Organizations API access
+chprof org && aws organizations list-accounts --region us-east-1
+```
+
+This is required because:
+- Claude Code runs each bash command in separate shell sessions
+- Environment variables (AWS_PROFILE) don't persist between commands
+- AWS Organizations API requires proper IAM permissions in the management account

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-AWSID is a Go CLI tool that retrieves AWS account IDs from alias names using AWS Organizations API. It's a single-file Go application (`main.go`) that automatically fetches account information and provides multiple output formats (standard, JSON, table, CSV).
+AWSID is a Go CLI tool that retrieves AWS account IDs from alias names using the AWS Organizations API. It's a single-file Go application (`main.go`) that automatically fetches account information and provides multiple output formats (standard, JSON, table, CSV).
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,16 +52,16 @@ GOOS=windows GOARCH=amd64 go build -o awsid_windows_amd64.exe
 
 ## Dependencies
 
-- `github.com/spf13/cobra`: CLI framework
-- `github.com/olekukonko/tablewriter`: Table output formatting
-- `github.com/aws/aws-sdk-go-v2/*`: AWS SDK for Organizations API
+- `github.com/spf13/cobra` - CLI framework
+- `github.com/olekukonko/tablewriter` - Table output formatting
+- `github.com/aws/aws-sdk-go-v2/*` - AWS SDK for Organizations API
 
 ## Important Notes
 
 - AWS Organizations API calls are hardcoded to use us-east-1 region
 - Account info file location is fixed at `~/.aws/account_info`
 - No test files exist currently - consider adding when implementing new features
-- Version is hardcoded in main.go as a const (currently "0.4.0")
+- Version is hardcoded in main.go as a const (currently "0.5.0")
 
 ## AWS Organizations Access
 

--- a/issue/issue-2.md
+++ b/issue/issue-2.md
@@ -1,0 +1,17 @@
+コマンド実行時に AWS Organizations にアクセスし、
+`aws organizations list-accounts` で取得できる各アカウントの情報をCSV形式で`~/.aws/account_info`に保存したい。
+現在は alias_name,account_id だけなので、それを拡張する形になります。
+以下は取得したJSONの例です。
+```json
+        {
+            "Id": "058264188814",
+            "Arn": "arn:aws:organizations::691610352964:account/o-8pr5zme5bo/058264188814",
+            "Email": "judydoctrine+iam-bation@gmail.com",
+            "Name": "pjuliar-accountname-iam-bastion",
+            "Status": "ACTIVE",
+            "JoinedMethod": "CREATED",
+            "JoinedTimestamp": "2024-02-24T13:08:50.690000+09:00"
+        }
+```
+
+上記のJSONの例をCSVにすると以下のようになります。

--- a/issue/issue-2.md
+++ b/issue/issue-2.md
@@ -15,3 +15,8 @@
 ```
 
 上記のJSONの例をCSVにすると以下のようになります。
+
+```csv
+id,arn,email,name,status,joined_method,joined_timestamp
+058264188814,arn:aws:organizations::691610352964:account/o-8pr5zme5bo/058264188814,judydoctrine+iam-bation@gmail.com,pjuliar-accountname-iam-bastion,ACTIVE,CREATED,2024-02-24T13:08:50.690000+09:00
+```

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ type AccountInfoList struct {
 	Accounts []AccountInfo `json:"account_info"`
 }
 
-const Version = "0.4.0"
+const Version = "0.5.0"
 
 func main() {
 	var jsonOutput bool

--- a/main.go
+++ b/main.go
@@ -16,6 +16,14 @@ import (
 )
 
 type AccountInfo struct {
+	ID            string `json:"id"`
+	Arn           string `json:"arn"`
+	Email         string `json:"email"`
+	Name          string `json:"name"`
+	Status        string `json:"status"`
+	JoinedMethod  string `json:"joined_method"`
+	JoinedTimestamp string `json:"joined_timestamp"`
+	// Backward compatibility fields
 	AliasName string `json:"alias_name"`
 	AccountID string `json:"account_id"`
 }
@@ -70,7 +78,8 @@ func main() {
 					outputCSV(accounts)
 				} else {
 					for _, account := range accounts {
-						fmt.Printf("%s: %s\n", account.AliasName, account.AccountID)
+						fmt.Printf("ID: %s | ARN: %s | Email: %s | Name: %s | Status: %s | Method: %s | Joined: %s\n", 
+							account.ID, account.Arn, account.Email, account.Name, account.Status, account.JoinedMethod, account.JoinedTimestamp)
 					}
 				}
 				return
@@ -128,7 +137,8 @@ func main() {
 			// If partial matches found, print them
 			if len(matchingAccounts) > 0 {
 				for _, account := range matchingAccounts {
-					fmt.Printf("%s: %s\n", account.AliasName, account.AccountID)
+					fmt.Printf("ID: %s | ARN: %s | Email: %s | Name: %s | Status: %s | Method: %s | Joined: %s\n", 
+						account.ID, account.Arn, account.Email, account.Name, account.Status, account.JoinedMethod, account.JoinedTimestamp)
 				}
 				return
 			}
@@ -172,15 +182,41 @@ func readAccountInfo(filePath string) ([]AccountInfo, error) {
 	// Process CSV records
 	for i, record := range records {
 		// Skip header row if it looks like a header
-		if i == 0 && (record[0] == "alias_name" || record[0] == "AliasName") {
+		if i == 0 && (len(record) > 0 && (record[0] == "alias_name" || record[0] == "AliasName" || record[0] == "id")) {
 			continue
 		}
 		
-		if len(record) >= 2 && record[0] != "" && record[1] != "" {
-			accounts = append(accounts, AccountInfo{
-				AliasName: strings.TrimSpace(record[0]),
-				AccountID: strings.TrimSpace(record[1]),
-			})
+		if len(record) >= 2 && record[0] != "" {
+			var account AccountInfo
+			
+			// Check if this is the new format (7 columns) or old format (2 columns)
+			if len(record) >= 7 {
+				// New format: id, arn, email, name, status, joined_method, joined_timestamp
+				account = AccountInfo{
+					ID:            strings.TrimSpace(record[0]),
+					Arn:           strings.TrimSpace(record[1]),
+					Email:         strings.TrimSpace(record[2]),
+					Name:          strings.TrimSpace(record[3]),
+					Status:        strings.TrimSpace(record[4]),
+					JoinedMethod:  strings.TrimSpace(record[5]),
+					JoinedTimestamp: strings.TrimSpace(record[6]),
+					// Backward compatibility
+					AliasName:     strings.TrimSpace(record[3]), // Name -> AliasName
+					AccountID:     strings.TrimSpace(record[0]), // ID -> AccountID
+				}
+			} else if len(record) >= 2 {
+				// Old format: alias_name, account_id
+				account = AccountInfo{
+					ID:            strings.TrimSpace(record[1]), // account_id -> ID
+					Name:          strings.TrimSpace(record[0]), // alias_name -> Name
+					AliasName:     strings.TrimSpace(record[0]),
+					AccountID:     strings.TrimSpace(record[1]),
+				}
+			}
+			
+			if account.ID != "" {
+				accounts = append(accounts, account)
+			}
 		}
 	}
 	
@@ -204,10 +240,18 @@ func outputJSON(accounts []AccountInfo) {
 
 func outputTable(accounts []AccountInfo) {
 	table := tablewriter.NewTable(os.Stdout)
-	table.Header("Alias Name", "Account ID")
+	table.Header("ID", "ARN", "Email", "Name", "Status", "Joined Method", "Joined Timestamp")
 
 	for _, account := range accounts {
-		table.Append([]any{account.AliasName, account.AccountID})
+		table.Append([]any{
+			account.ID, 
+			account.Arn, 
+			account.Email, 
+			account.Name, 
+			account.Status, 
+			account.JoinedMethod, 
+			account.JoinedTimestamp,
+		})
 	}
 
 	table.Render()
@@ -217,11 +261,19 @@ func outputCSV(accounts []AccountInfo) {
 	defer writer.Flush()
 
 	// Write header
-	writer.Write([]string{"alias_name", "account_id"})
+	writer.Write([]string{"id", "arn", "email", "name", "status", "joined_method", "joined_timestamp"})
 
 	// Write data
 	for _, account := range accounts {
-		writer.Write([]string{account.AliasName, account.AccountID})
+		writer.Write([]string{
+			account.ID, 
+			account.Arn, 
+			account.Email, 
+			account.Name, 
+			account.Status, 
+			account.JoinedMethod, 
+			account.JoinedTimestamp,
+		})
 	}
 }
 
@@ -252,10 +304,27 @@ func updateAccountInfoFromAWS(filePath string) error {
 	var accounts []AccountInfo
 	for _, account := range result.Accounts {
 		if account.Id != nil && account.Name != nil {
-			accounts = append(accounts, AccountInfo{
+			accountInfo := AccountInfo{
+				ID:     *account.Id,
+				Name:   *account.Name,
+				// Backward compatibility
 				AliasName: *account.Name,
 				AccountID: *account.Id,
-			})
+			}
+			
+			if account.Arn != nil {
+				accountInfo.Arn = *account.Arn
+			}
+			if account.Email != nil {
+				accountInfo.Email = *account.Email
+			}
+			accountInfo.Status = string(account.Status)
+			accountInfo.JoinedMethod = string(account.JoinedMethod)
+			if account.JoinedTimestamp != nil {
+				accountInfo.JoinedTimestamp = account.JoinedTimestamp.Format("2006-01-02T15:04:05.000000-07:00")
+			}
+			
+			accounts = append(accounts, accountInfo)
 		}
 	}
 
@@ -274,13 +343,21 @@ func saveAccountInfoToCSV(filePath string, accounts []AccountInfo) error {
 	defer writer.Flush()
 
 	// Write header
-	if err := writer.Write([]string{"alias_name", "account_id"}); err != nil {
+	if err := writer.Write([]string{"id", "arn", "email", "name", "status", "joined_method", "joined_timestamp"}); err != nil {
 		return fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
 	// Write data
 	for _, account := range accounts {
-		if err := writer.Write([]string{account.AliasName, account.AccountID}); err != nil {
+		if err := writer.Write([]string{
+			account.ID, 
+			account.Arn, 
+			account.Email, 
+			account.Name, 
+			account.Status, 
+			account.JoinedMethod, 
+			account.JoinedTimestamp,
+		}); err != nil {
 			return fmt.Errorf("failed to write CSV data: %w", err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -243,7 +243,7 @@ func outputTable(accounts []AccountInfo) {
 	table.Header("ID", "ARN", "Email", "Name", "Status", "Joined Method", "Joined Timestamp")
 
 	for _, account := range accounts {
-		table.Append([]any{
+		err := table.Append([]any{
 			account.ID, 
 			account.Arn, 
 			account.Email, 
@@ -252,6 +252,10 @@ func outputTable(accounts []AccountInfo) {
 			account.JoinedMethod, 
 			account.JoinedTimestamp,
 		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error appending table row: %v\n", err)
+			continue
+		}
 	}
 
 	table.Render()
@@ -261,11 +265,14 @@ func outputCSV(accounts []AccountInfo) {
 	defer writer.Flush()
 
 	// Write header
-	writer.Write([]string{"id", "arn", "email", "name", "status", "joined_method", "joined_timestamp"})
+	if err := writer.Write([]string{"id", "arn", "email", "name", "status", "joined_method", "joined_timestamp"}); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing CSV header: %v\n", err)
+		return
+	}
 
 	// Write data
 	for _, account := range accounts {
-		writer.Write([]string{
+		if err := writer.Write([]string{
 			account.ID, 
 			account.Arn, 
 			account.Email, 
@@ -273,7 +280,10 @@ func outputCSV(accounts []AccountInfo) {
 			account.Status, 
 			account.JoinedMethod, 
 			account.JoinedTimestamp,
-		})
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing CSV row: %v\n", err)
+			continue
+		}
 	}
 }
 


### PR DESCRIPTION
## 概要

コマンド実行時にAWS Organizations APIから取得できる全ての情報をCSV形式で`~/.aws/account_info`に保存する機能を実装しました。

Closes #15

## 背景

Issue #15の対応として、従来の2列（alias_name, account_id）から7列の詳細情報を保存できるように拡張しました。

## 内容詳細

### 新機能
- **AccountInfo構造体を拡張**: 7つのフィールド（ID, ARN, Email, Name, Status, JoinedMethod, JoinedTimestamp）に対応
- **CSV保存の拡張**: 新フォーマット `id,arn,email,name,status,joined_method,joined_timestamp` で保存
- **デフォルト出力の改善**: 引数なしで実行時に7つのフィールドを表示

### 下位互換性
- 古い2列CSVファイルの読み込みをサポート
- 検索機能は従来通り動作
- 完全一致時はAccountIDのみ表示（既存動作を維持）

### 技術的改善
- AWS SDK v2のenum型（Status, JoinedMethod）エラーを修正
- 新旧両フォーマットの自動判定機能

### 出力例
```
ID: 058264188814 | ARN: arn:aws:organizations::... | Email: user@example.com | Name: account-name | Status: ACTIVE | Method: CREATED | Joined: 2024-02-24T13:08:50...
```

## レビューポイント

- 下位互換性が適切に維持されているか
- AWS Organizations APIアクセス権限の要件
- 新しいCSVフォーマットの妥当性

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced account information output to include additional fields such as ID, ARN, Email, Name, Status, Joined Method, and Joined Timestamp, providing more detailed AWS account metadata.
- **Documentation**
  - Added a comprehensive guide for using the tool with Claude Code, including architecture, development commands, and AWS access instructions.
  - Documented new requirements and example formats for extended account information in CSV output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->