### PR TITLE
ソート機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ awsid --name test
 # test を含むアカウント名で検索
 ```
 
+結果をソート：
+
+```bash
+awsid --sort name              # アカウント名昇順
+awsid --sort-desc name         # アカウント名降順
+awsid --sort joined_timestamp  # 作成日昇順
+awsid --sort-desc joined_timestamp  # 作成日降順（新しい順）
+```
+
 ## 出力形式
 
 出力形式は以下の方法で指定できます：
@@ -95,6 +104,44 @@ awsid --csv           # CSV形式
 ```
 
 **注意**: `--format`オプションと個別フラグが同時に指定された場合、`--format`が優先されます。
+
+## ソート機能
+
+結果は以下のフィールドでソートできます：
+
+### ソートオプション
+
+```bash
+awsid --sort <field>        # 昇順ソート
+awsid --sort-desc <field>   # 降順ソート
+```
+
+### 利用可能なソートフィールド
+
+- `id` - アカウントID
+- `name` - アカウント名
+- `email` - メールアドレス
+- `status` - ステータス
+- `joined_timestamp` - 作成日時
+- `joined_method` - 参加方法
+
+### ソート例
+
+```bash
+# アカウント名でアルファベット順
+awsid --sort name --format table
+
+# 最新作成順
+awsid --sort-desc joined_timestamp
+
+# 検索結果をソート
+awsid --name test --sort name
+
+# JSON形式でメールアドレス順
+awsid --sort email --format json
+```
+
+**注意**: `--sort`と`--sort-desc`は同時に指定できません。
 
 ### 標準出力（デフォルト）
 


### PR DESCRIPTION
## 概要
Issue #30に基づくアカウント一覧表示時のソート機能実装

## 背景
大量のアカウントがある場合の管理効率化とユーザビリティ向上のため

## 内容詳細
- ✅ `--sort <field>` フラグ実装（昇順ソート）
- ✅ `--sort-desc <field>` フラグ実装（降順ソート）
- ✅ 6つのソートフィールド対応（id, name, email, status, joined_timestamp, joined_method）
- ✅ 全出力フォーマット対応（default, json, table, csv）
- ✅ 検索機能との組み合わせ対応
- ✅ エラーハンドリング（無効フィールド、競合フラグ検出）
- ✅ 下位互換性完全維持
- ✅ 包括的ドキュメント更新

## テスト内容
- 各フィールドの昇順・降順ソート動作確認
- 検索とソートの組み合わせテスト
- フォーマットとソートの組み合わせテスト
- エラーハンドリング（無効フィールド、競合フラグ）
- パフォーマンス確認

## 使用例
```bash
# アカウント名でアルファベット順
awsid --sort name --format table

# 最新作成順
awsid --sort-desc joined_timestamp

# 検索結果をソート
awsid --name test --sort name
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced sorting options for the AWS account list output, allowing users to sort by fields such as ID, name, email, status, joined date, and joined method in ascending or descending order using new command-line flags.
- **Documentation**
  - Updated the README with detailed instructions, examples, and usage notes for the new sorting feature and its options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->